### PR TITLE
Fix variables to use ansible syntax

### DIFF
--- a/tasks/fetch.yml
+++ b/tasks/fetch.yml
@@ -3,15 +3,15 @@
 
 - name: Fetch sosreport archive md5
   fetch: >
-    src=$tmpdir/$diag_filename.md5
-    dest=/tmp/jsos/$ansible_hostname/
+    src={{ tmpdir }}/{{ diag_filename }}.md5
+    dest={{ diag_path }}/{{ ansible_hostname }}/
     fail_on_missing=yes
     flat=yes
     validate_md5=yes
 
 - name: Fetch sosreport archives
   fetch: >
-    src=$tmpdir/$diag_filename
-    dest=$diag_path/$ansible_hostname/
+    src={{ tmpdir }}/{{ diag_filename }}
+    dest={{ diag_path }}/{{ ansible_hostname }}/
     flat=yes
     validate_md5=no

--- a/tasks/run.yml
+++ b/tasks/run.yml
@@ -2,25 +2,25 @@
 # Task:  Run sosreport to generate diagnostics
 #
 # Variables:
-#   $tmpdir is the remote tmp directory to use for diag creation
-#   $diag_filename is the base 
+#   {{ tmpdir }} is the remote tmp directory to use for diag creation
+#   {{ diag_filename }} is the base
 
-- name: Clean tmpdir $tmpdir
-  file: path=$tmpdir state=absent
+- name: Clean tmpdir {{ tmpdir }}
+  file: path={{ tmpdir }} state=absent
 
-- name: Create empty tmpdir $tmpdir
-  file: path=$tmpdir state=directory
+- name: Create empty tmpdir {{ tmpdir }}
+  file: path={{ tmpdir }} state=directory
 
-- name: Run PATH=$sosreport_path:\$PATH $sosreport_cmd $sosreport_args to generate $diag_filename in tmpdir $tmpdir
+- name: Run PATH={{sosreport_path}}:\$PATH {{ sosreport_cmd }} {{ sosreport_args }} to generate {{ diag_filename }} in tmpdir {{ tmpdir }}
   shell: "PATH={{ sosreport_path }}:$PATH {{ sosreport_cmd }} {{ sosreport_args }} --batch --tmp-dir {{ tmpdir }}"
   when: sosreport_path is defined
 
-- name: Run $sosreport_cmd $sosreport_args to generate $diag_filename in $tmpdir
+- name: Run {{ sosreport_cmd }} {{ sosreport_args }} to generate {{ diag_filename }} in {{ tmpdir }}
   shell: "{{ sosreport_cmd }} {{ sosreport_args }} --batch --tmp-dir {{ tmpdir }}"
   when: sosreport_path is not defined
 
-- name: Rename sosreport MD5 file to $diag_filename.md5
+- name: Rename sosreport MD5 file to {{ diag_filename }}.md5
   shell: mv -f {{ tmpdir }}/*.md5 {{ tmpdir }}/{{ diag_filename }}.md5
 
-- name: Rename sosreport archive file to $diag_filename
+- name: Rename sosreport archive file to {{ diag_filename }}
   shell: mv -f {{ tmpdir }}/*.tar.xz {{ tmpdir }}/{{ diag_filename }}


### PR DESCRIPTION
A number of variables in the run and fetch playbook were defined using
shell $varname syntax. This was causing problems with the playbook since
those strings were treated a literal values on the target causing the
playbooks to fail.

Also aligned the fetch of the md5 and tarball targets to reference the
same local directory variable.